### PR TITLE
Side Containers will have specified name as input in textfield instead of random names.

### DIFF
--- a/src/main/java/it/dockins/dockerslaves/DefaultDockerProvisioner.java
+++ b/src/main/java/it/dockins/dockerslaves/DefaultDockerProvisioner.java
@@ -119,7 +119,7 @@ public class DefaultDockerProvisioner extends DockerProvisioner {
             final ContainerDefinition sidecar = definition.getSpec();
             final String image = sidecar.getImage(driver, starter.pwd(), listener);
             listener.getLogger().println("Starting " + name + " container");
-            Container container = driver.launchSideContainer(listener, image, context.getRemotingContainer(), sidecar.getHints());
+            Container container = driver.launchSideContainer(listener, image, context.getRemotingContainer(), sidecar.getHints(), name);
             context.getSideContainers().put(name, container);
         }
     }

--- a/src/main/java/it/dockins/dockerslaves/drivers/CliDockerDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliDockerDriver.java
@@ -357,9 +357,10 @@ public class CliDockerDriver extends DockerDriver {
     private static final Logger LOGGER = Logger.getLogger(ProvisionQueueListener.class.getName());
 
     @Override
-    public Container launchSideContainer(TaskListener listener, String image, Container remotingContainer, List<Hint> hints) throws IOException, InterruptedException {
+    public Container launchSideContainer(TaskListener listener, String image, Container remotingContainer, List<Hint> hints, String containerName) throws IOException, InterruptedException {
         ArgumentListBuilder args = new ArgumentListBuilder()
                 .add("create")
+                .add("--name",containerName)
                 .add("--volumes-from", remotingContainer.getId())
                 .add("--net=container:" + remotingContainer.getId())
                 .add("--ipc=container:" + remotingContainer.getId());
@@ -502,3 +503,4 @@ public class CliDockerDriver extends DockerDriver {
 
     public static final String UTF_8 = StandardCharsets.UTF_8.name();
 }
+

--- a/src/main/java/it/dockins/dockerslaves/spi/DockerDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/spi/DockerDriver.java
@@ -29,7 +29,7 @@ public abstract class DockerDriver implements Closeable {
 
     public abstract Container launchBuildContainer(TaskListener listener, String image, Container remotingContainer, List<Hint> hints) throws IOException, InterruptedException;
 
-    public abstract Container launchSideContainer(TaskListener listener, String image, Container remotingContainer, List<Hint> hints) throws IOException, InterruptedException;
+    public abstract Container launchSideContainer(TaskListener listener, String image, Container remotingContainer, List<Hint> hints, String containerName) throws IOException, InterruptedException;
 
     public abstract Proc execInContainer(TaskListener listener, String containerId, Launcher.ProcStarter starter) throws IOException, InterruptedException;
 


### PR DESCRIPTION
Previously, the side containers were having **random names** .
Now, the **containers will have names as specified** while adding the side containers in the configuration page.
Eg.- 'docker ps' resulted in containers running with container id and random names previously, but now will have specific names.