### PR TITLE
Use the item id as container name

### DIFF
--- a/src/main/java/it/dockins/dockerslaves/ProvisionQueueListener.java
+++ b/src/main/java/it/dockins/dockerslaves/ProvisionQueueListener.java
@@ -83,11 +83,11 @@ public class ProvisionQueueListener extends QueueListener {
     }
 
     private Node prepareExecutorFor(final Queue.BuildableItem item, final AbstractProject job) throws Descriptor.FormException, IOException, InterruptedException {
-        LOGGER.info("Creating a Container slave to host " + job.toString() + "#" + job.getNextBuildNumber());
+        LOGGER.info("Creating a container slave to host " + job.toString() + ", item id " + item.getId());
 
         // Immediately create a slave for this item
         // Real provisioning will happen later
-        String slaveName = "Container for " +job.getName() + "#" + job.getNextBuildNumber();
+        String slaveName = "Container for item " + item.getId();
         String description = "Container slave for building " + job.getFullName();
         DockerSlaves plugin = DockerSlaves.get();
         return new DockerSlave(slaveName, description, null, plugin.createStandardJobProvisionerFactory(job),item);


### PR DESCRIPTION
The next build number is not unique when a job can be run
concurrently. This leads to items getting stuck in the build queue
as the container to which queued items will be cleaned up when the
associated job finishes.