### PR TITLE
Implemetation of `Raw Options` in Advanced Settings

### DIFF
--- a/src/main/java/it/dockins/dockerslaves/drivers/CliDockerDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliDockerDriver.java
@@ -40,6 +40,7 @@ import it.dockins.dockerslaves.DockerSlave;
 import it.dockins.dockerslaves.ProvisionQueueListener;
 import it.dockins.dockerslaves.hints.MemoryHint;
 import it.dockins.dockerslaves.hints.VolumeHint;
+import it.dockins.dockerslaves.hints.RawOptionsHint;
 import it.dockins.dockerslaves.spec.Hint;
 import it.dockins.dockerslaves.spi.DockerDriver;
 import it.dockins.dockerslaves.spi.DockerHostConfig;
@@ -63,6 +64,7 @@ import static it.dockins.dockerslaves.DockerSlave.SLAVE_ROOT;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  * @author <a href="mailto:yoann.dubreuil@gmail.com">Yoann Dubreuil</a>
+ * @author <a href="mailto:leks.molecul@gmail.com">Alexey Galkin</a>
  */
 public class CliDockerDriver extends DockerDriver {
 
@@ -240,6 +242,8 @@ public class CliDockerDriver extends DockerDriver {
                 args.add("-m", ((MemoryHint) hint).getMemory());
             } else if (hint instanceof VolumeHint) {
                 args.add("-v", ((VolumeHint) hint).getVolume());
+            } else if (hint instanceof RawOptionsHint) {
+                args.add(((RawOptionsHint) hint).getOptions());
             } else {
                 // unsupported hint, just ignored
             }

--- a/src/main/java/it/dockins/dockerslaves/hints/RawOptionsHint.java
+++ b/src/main/java/it/dockins/dockerslaves/hints/RawOptionsHint.java
@@ -1,0 +1,32 @@
+package it.dockins.dockerslaves.hints;
+
+import hudson.Extension;
+import it.dockins.dockerslaves.spec.Hint;
+import it.dockins.dockerslaves.spec.HintDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author <a href="mailto:alexey.galkin@gmail.com">Alexey Galkin</a>
+ */
+public class RawOptionsHint extends Hint{
+
+    private final String options;
+
+    @DataBoundConstructor
+    public RawOptionsHint(String options) {
+        this.options = options;
+    }
+
+    public String getOptions() {
+        return options;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends HintDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Raw Options";
+        }
+    }
+}

--- a/src/main/resources/it/dockins/dockerslaves/hints/RawOptionsHint/config.jelly
+++ b/src/main/resources/it/dockins/dockerslaves/hints/RawOptionsHint/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+   <f:entry field="options" title="Raw Options">
+      <f:textbox/>
+   </f:entry>
+
+</j:jelly>

--- a/src/main/resources/it/dockins/dockerslaves/hints/RawOptionsHint/help-options.html
+++ b/src/main/resources/it/dockins/dockerslaves/hints/RawOptionsHint/help-options.html
@@ -1,0 +1,2 @@
+Define raw options line for container. <br>
+<b>For example</b>: <code>--mount source=nginx-vol,destination=/usr/share/nginx/html,readonly</code>


### PR DESCRIPTION
This commit contains implementation of `Raw Options`,
it will allow you to flexibly supplement command to
start the container.

![image](https://user-images.githubusercontent.com/6001999/36981933-7ebc60b0-209f-11e8-85f9-9872957c39a9.png)
